### PR TITLE
#980: YCQL Ruby driver: use quorum consistency level by default

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -228,7 +228,7 @@ session.execute(batch, consistency: :all)
 [Read more about `Session#execute`](http://datastax.github.io/ruby-driver/api/session/#execute-instance_method)
 [Read more about possible consistencies](http://datastax.github.io/ruby-driver/api/#CONSISTENCIES-constant)
 
-The default consistency level unless you've set it yourself is `:local_one`.
+The default consistency level unless you've set it yourself is `:quorum`.
 
 Consistency is ignored for `USE`, `TRUNCATE`, `CREATE` and `ALTER` statements, and some (like `:any`) aren't allowed in all situations.
 

--- a/features/basics/execution_profiles.feature
+++ b/features/basics/execution_profiles.feature
@@ -14,7 +14,7 @@ Feature: Execution profiles
 
   * load_balancing_policy: `LoadBalancing::Policies::TokenAware.new(LoadBalancing::Policies::DCAwareRoundRobin.new, true)`
   * retry-policy: `Retry::Policies::Default.new`
-  * consistency: `:local_one`
+  * consistency: `:quorum`
   * timeout: `12`
 
   In particular, note that user-defined execution profiles do not fall back to options specified in a (possibly

--- a/lib/cassandra/cluster/client.rb
+++ b/lib/cassandra/cluster/client.rb
@@ -375,14 +375,14 @@ module Cassandra
           'SELECT peer, rpc_address, schema_version FROM system.peers',
           EMPTY_LIST,
           EMPTY_LIST,
-          :one
+          :quorum
         )
       SELECT_SCHEMA_LOCAL =
         Protocol::QueryRequest.new(
           "SELECT schema_version FROM system.local WHERE key='local'",
           EMPTY_LIST,
           EMPTY_LIST,
-          :one
+          :quorum
         )
 
       def connected(f)
@@ -1533,7 +1533,7 @@ module Cassandra
         request = Protocol::QueryRequest.new("USE #{Util.escape_name(keyspace)}",
                                              EMPTY_LIST,
                                              EMPTY_LIST,
-                                             :one)
+                                             :quorum)
 
         f = connection.send_request(request, timeout).map do |r|
           case r
@@ -1545,7 +1545,7 @@ module Cassandra
                              Statements::Simple.new("USE #{Util.escape_name(keyspace)}"),
                              VOID_OPTIONS,
                              EMPTY_LIST,
-                             :one,
+                             :quorum,
                              0)
           else
             raise Errors::InternalError, "Unexpected response #{r.inspect}"
@@ -1582,7 +1582,7 @@ module Cassandra
             end
             id
           when Protocol::ErrorResponse
-            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
           else
             raise Errors::InternalError, "Unexpected response #{r.inspect}"
           end
@@ -1601,7 +1601,7 @@ module Cassandra
           when Protocol::RowsResultResponse
             r.rows
           when Protocol::ErrorResponse
-            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
           else
             raise Errors::InternalError, "Unexpected response #{r.inspect}"
           end

--- a/lib/cassandra/cluster/connector.rb
+++ b/lib/cassandra/cluster/connector.rb
@@ -222,7 +222,7 @@ module Cassandra
             ::Ione::Future.resolved(connection)
           when Protocol::ErrorResponse
             ::Ione::Future.failed(
-              r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+              r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
             )
           else
             ::Ione::Future.failed(
@@ -242,7 +242,7 @@ module Cassandra
           VOID_STATEMENT,
           VOID_OPTIONS,
           EMPTY_LIST,
-          :one,
+          :quorum,
           0
         )
       end
@@ -254,7 +254,7 @@ module Cassandra
           when Protocol::SupportedResponse
             r.options
           when Protocol::ErrorResponse
-            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
           else
             raise Errors::InternalError, "Unexpected response #{r.inspect}"
           end
@@ -268,7 +268,7 @@ module Cassandra
           when Protocol::ReadyResponse
             connection
           when Protocol::ErrorResponse
-            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
           else
             raise Errors::InternalError, "Unexpected response #{r.inspect}"
           end
@@ -291,7 +291,7 @@ module Cassandra
             ::Ione::Future.resolved(connection)
           when Protocol::ErrorResponse
             ::Ione::Future.failed(
-              r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+              r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
             )
           else
             ::Ione::Future.failed(

--- a/lib/cassandra/cluster/control_connection.rb
+++ b/lib/cassandra/cluster/control_connection.rb
@@ -154,14 +154,14 @@ module Cassandra
           'FROM system.local',
         EMPTY_LIST,
         EMPTY_LIST,
-        :one
+        :quorum
       )
       SELECT_PEERS = Protocol::QueryRequest.new(
         'SELECT * ' \
           'FROM system.peers',
         EMPTY_LIST,
         EMPTY_LIST,
-        :one
+        :quorum
       )
 
       SELECT_PEER_QUERY =
@@ -211,7 +211,7 @@ module Cassandra
           when Protocol::ReadyResponse
             nil
           when Protocol::ErrorResponse
-            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+            raise r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
           else
             raise Errors::InternalError, "Unexpected response #{r.inspect}"
           end
@@ -582,7 +582,7 @@ module Cassandra
                     Protocol::QueryRequest.new(SELECT_PEER_QUERY % ip,
                                                EMPTY_LIST,
                                                EMPTY_LIST,
-                                               :one)
+                                               :quorum)
                   end
 
         send_select_request(connection, request).map do |rows|
@@ -949,7 +949,7 @@ Control connection failed and is unlikely to recover.
           when Protocol::RowsResultResponse
             r.rows
           when Protocol::ErrorResponse
-            e = r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+            e = r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
             e.set_backtrace(backtrace)
             raise e
           else

--- a/lib/cassandra/cluster/schema/fetchers.rb
+++ b/lib/cassandra/cluster/schema/fetchers.rb
@@ -262,13 +262,13 @@ module Cassandra
         def send_select_request(connection, cql, params = EMPTY_LIST, types = EMPTY_LIST)
           backtrace = caller
           connection.send_request(
-            Protocol::QueryRequest.new(cql, params, types, :one)
+            Protocol::QueryRequest.new(cql, params, types, :quorum)
           ).map do |r|
             case r
             when Protocol::RowsResultResponse
               r.rows
             when Protocol::ErrorResponse
-              e = r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :one, 0)
+              e = r.to_error(nil, VOID_STATEMENT, VOID_OPTIONS, EMPTY_LIST, :quorum, 0)
               e.set_backtrace(backtrace)
               raise e
             else

--- a/lib/cassandra/driver.rb
+++ b/lib/cassandra/driver.rb
@@ -168,7 +168,7 @@ module Cassandra
     end
     let(:retry_policy)              { Retry::Policies::Default.new }
     let(:address_resolution_policy) { AddressResolution::Policies::None.new }
-    let(:consistency)               { :local_one }
+    let(:consistency)               { :quorum }
     let(:trace)                     { false }
     let(:page_size)                 { 10000 }
     let(:heartbeat_interval)        { 30 }

--- a/lib/cassandra/execution/profile.rb
+++ b/lib/cassandra/execution/profile.rb
@@ -43,7 +43,7 @@ module Cassandra
       attr_reader :timeout
 
       # @private
-      DEFAULT_OPTIONS = { consistency: :local_one, timeout: 12 }.freeze
+      DEFAULT_OPTIONS = { consistency: :quorum, timeout: 12 }.freeze
 
       # @param options [Hash] hash of attributes. Unspecified attributes fall back to system defaults.
       # @option options [Numeric] :timeout (12) Request execution timeout in
@@ -53,7 +53,7 @@ module Cassandra
       #   that determines which node will run the next statement.
       # @option options [Cassandra::Retry::Policy] :retry_policy (Retry::Policies::Default) Retry policy that
       #   determines how request retries should be handled for different failure modes.
-      # @option options [Symbol] :consistency (:local_one) Consistency level with which to run statements. Must be one
+      # @option options [Symbol] :consistency (:quorum) Consistency level with which to run statements. Must be one
       #   of {Cassandra::CONSISTENCIES}.
       def initialize(options = {})
         validate(options)

--- a/lib/cassandra/protocol/requests/prepare_request.rb
+++ b/lib/cassandra/protocol/requests/prepare_request.rb
@@ -26,7 +26,7 @@ module Cassandra
         raise ArgumentError, 'No CQL given!' unless cql
         super(9, trace)
         @cql = cql
-        @consistency = :one
+        @consistency = :quorum
         @payload = payload
       end
 

--- a/lib/cassandra/session.rb
+++ b/lib/cassandra/session.rb
@@ -47,7 +47,7 @@ module Cassandra
     # @option options [Symbol] :consistency consistency level for the request.
     #   Must be one of {Cassandra::CONSISTENCIES}. Defaults to the setting in the
     #   active execution profile. If none is specified, the default profile is used,
-    #   which is set to `:local_one`.
+    #   which is set to `:quorum`.
     # @option options [Integer] :page_size size of results page. You can page
     #   through results using {Cassandra::Result#next_page} or
     #   {Cassandra::Result#next_page_async}

--- a/lib/ycql.rb
+++ b/lib/ycql.rb
@@ -246,7 +246,7 @@ module Cassandra
   #   initial listeners. A list of initial cluster state listeners. Note that a
   #   `:load_balancing` policy is automatically registered with the cluster.
   #
-  # @option options [Symbol] :consistency (:local_one) default consistency
+  # @option options [Symbol] :consistency (:local_quorum) default consistency
   #   to use for all requests. Must be one of {Cassandra::CONSISTENCIES}.
   #
   # @option options [Boolean] :trace (false) whether or not to trace all
@@ -834,7 +834,7 @@ module Cassandra
   # @private
   VOID_STATEMENT = Statements::Void.new
   # @private
-  VOID_OPTIONS   = Execution::Options.new(consistency: :one,
+  VOID_OPTIONS   = Execution::Options.new(consistency: :quorum,
                                           load_balancing_policy: LoadBalancing::Policies::RoundRobin.new,
                                           retry_policy: Retry::Policies::Default.new)
   # @private


### PR DESCRIPTION
https://github.com/YugaByte/yugabyte-db/issues/980